### PR TITLE
Add support for Callout Name `(*FAIL)`

### DIFF
--- a/src/parser/parse.js
+++ b/src/parser/parse.js
@@ -35,6 +35,7 @@ const NodeTypes = /** @type {const} */ ({
   Directive: 'Directive',
   Flags: 'Flags',
   Group: 'Group',
+  Callout: 'Callout',
   LookaroundAssertion: 'LookaroundAssertion',
   Pattern: 'Pattern',
   Quantifier: 'Quantifier',
@@ -219,6 +220,8 @@ function parse(pattern, options = {}) {
           throwIfNot(NodeDirectiveKinds[token.kind], `Unexpected directive kind "${token.kind}"`),
           {flags: token.flags}
         );
+      case TokenTypes.Callout:
+        return parseCallout();
       case TokenTypes.GroupOpen:
         return parseGroupOpen(context, state);
       case TokenTypes.Quantifier:
@@ -401,6 +404,13 @@ function parseCharacterSet({token, normalizeUnknownPropertyNames, skipPropertyNa
     return createPosixClass(value, {negate});
   }
   return createCharacterSet(kind, {negate});
+}
+
+function parseCallout() {
+  return createLookaroundAssertion({
+    behind: false,
+    negate: true,
+  });
 }
 
 function parseGroupOpen(context, state) {


### PR DESCRIPTION
support for `(*FAIL)`
just directly translates it to negative lookahead `(?!)` (or if you want to go smaller `[]` also cannot match (js only))
https://github.com/slevithan/oniguruma-to-es/issues/20

I haven't added any additional support for any other Callout names `(*SKIP)` etc

technically `tag` and `flag` are allowed, but idk why anyone would `(*FAIL[tag]{})`
optional `tag` must match `\[[_a-zA-Z][_a-zA-Z0-9]*\]`
optional `flag` must(?) be empty `{}`


seems to work
![image](https://github.com/user-attachments/assets/5f46706c-f094-4269-8d74-1d3a7daa155e)
![image](https://github.com/user-attachments/assets/aa45f77c-80ca-42a2-a18f-79c2b0ef2b09)
