### PR TITLE
Add `finalNewline` VSCode setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,8 @@
 {
   "editor.insertSpaces": true,
   "editor.tabSize": 2,
+  "files.trimFinalNewlines": true,
+  "files.insertFinalNewline": true,
   "javascript.format.semicolons": "insert",
   "javascript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces": false,
   "typescript.format.semicolons": "insert",


### PR DESCRIPTION
enforces files end with a single newline